### PR TITLE
Support multiline labels json

### DIFF
--- a/.github/workflows/test-pr-opened.yml
+++ b/.github/workflows/test-pr-opened.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        
+      - run: jq --version
 
       - uses: ./
         id: current

--- a/.github/workflows/test-pr-opened.yml
+++ b/.github/workflows/test-pr-opened.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        
-      - run: jq --version
 
       - uses: ./
         id: current

--- a/.github/workflows/test-pr-opened.yml
+++ b/.github/workflows/test-pr-opened.yml
@@ -29,7 +29,11 @@ jobs:
             qa2: deploy/qa2
             qa3: deploy/qa3
             qa4: deploy/qa4
-          labels: '["deploy","deploy/qa2"]'
+          labels: |
+            [
+              "deploy",
+              "deploy/qa2"
+            ]
           open: 'true'
 
       - uses: nick-fields/assert-action@v1


### PR DESCRIPTION
## what
* Support multiline labels json

## why
* It seem Github changed `labels` format from compact `["label1", "label2"]` to nice 
```
[ 
  "label1",
  "label2"
]
```
