### PR TITLE
`Data Format Converter Action` version bump

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         file: 'labels_env.yaml'
         content: ${{ inputs.env-label }}
 
-    - uses: fabasoad/data-format-converter-action@03bb3f2c090f7f45ebc5d80e917b93774b6a99c3 # > v0.2.1
+    - uses: fabasoad/data-format-converter-action@v0.2.3
       id: yaml2json
       with:
         input: 'labels_env.yaml'


### PR DESCRIPTION
## what
* Update to `@v0.2.3`

## why
* Bumps [robinraju/release-downloader](https://github.com/robinraju/release-downloader) from 1.8 to 1.9.
* Bumps [softprops/action-gh-release](https://github.com/softprops/action-gh-release) from 1 to 2.
* Bumps [robinraju/release-downloader](https://github.com/robinraju/release-downloader) from 1.9 to 1.10.
* Bump pre-commit dependencies to the latest version
  * Use reusable workflows for some of CI workflows
  * Update README
* Bumps [robinraju/release-downloader](https://github.com/robinraju/release-downloader) from 1.10 to 1.11.
