### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/test-jq-version.yml
+++ b/.github/workflows/test-jq-version.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: 'Setup jq'
         uses: dcarbone/install-jq-action@v2.1.0
@@ -39,7 +39,7 @@ jobs:
           chmod +x /opt/hostedtoolcache/jq/jq          
           echo "version=$(jq --version)" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'jq-1.5'
           actual: ${{ steps.base.outputs.version }}
@@ -62,18 +62,18 @@ jobs:
           jq --version
           echo "version=$(jq --version)" >> $GITHUB_OUTPUT
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'jq-1.6'
           actual: ${{ steps.new.outputs.version }}
 
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '["preview","qa2"]'
           actual: ${{ steps.current.outputs.deploy_envs }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '["qa1","qa3","qa4"]'
           actual: ${{ steps.current.outputs.destroy_envs }}

--- a/.github/workflows/test-pr-closed.yml
+++ b/.github/workflows/test-pr-closed.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -39,12 +39,12 @@ jobs:
           labels: '[ "deploy", "deploy/qa2" ]'
           open: false
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '[]'
           actual: ${{ steps.current.outputs.deploy_envs }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '["preview","qa2"]'
           actual: ${{ steps.current.outputs.destroy_envs }}

--- a/.github/workflows/test-pr-opened.yml
+++ b/.github/workflows/test-pr-opened.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -39,12 +39,12 @@ jobs:
           labels: '["deploy","deploy/qa2"]'
           open: 'true'
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '["preview","qa2"]'
           actual: ${{ steps.current.outputs.deploy_envs }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '["qa1","qa3","qa4"]'
           actual: ${{ steps.current.outputs.destroy_envs }}

--- a/action.yml
+++ b/action.yml
@@ -62,14 +62,14 @@ runs:
         version: 1.6
         force: 'true'
 
-    - uses: cloudposse/github-action-jq@0.4.0
+    - uses: cloudposse/github-action-jq@aff18a1f2e845b56fcfe995b01a558836dc2025b # v0.4.1
       id: deploy_envs
       with:
         compact: true
         input: ${{ steps.yaml2json.outputs.output }}
         script: ${{ format(steps.pattern.outputs.deploy, inputs.labels) }}
 
-    - uses: cloudposse/github-action-jq@0.4.0
+    - uses: cloudposse/github-action-jq@aff18a1f2e845b56fcfe995b01a558836dc2025b # v0.4.1
       id: destroy_envs
       with:
         compact: true


### PR DESCRIPTION
## what

* Bump GitHub Actions references to Node 24 runtimes, SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`
  * `cloudposse/github-action-jq@0.4.0` → `@aff18a1f...` `# v0.4.1` (0.4.0 runs node20; v0.4.1 is node24)

## why

* GitHub is deprecating the Node 20 runtime; these refs emit deprecation warnings for every
  consumer and are being force-migrated to Node 24
* SHA pinning with verified tag comments matches the org's supply-chain direction
  (cloudposse/.github#261); every pinned SHA was verified against its upstream tag
* Opened from a fork — direct branch push to this repo is not permitted for this account

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
* Supersedes Renovate #42 (checkout v7) and #41 (assert-action v4)

## still on Node 20

* `1arp/create-a-file-action@0.3` in `action.yml` — no node24 release exists (latest 0.4 is
  node20); needs replacement, tracked org-wide
